### PR TITLE
Add support for MULTI_QUEUE flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Tuncer is a stand up guy and just like him, tuncer has your back.
 
         Types   Device = [ string() | binary() ]
                 Options = [ Flag ]
-                Flag = [ tun | tap | no_pi | one_queue | vnet_hdr | tun_excl
+                Flag = [ tun | tap | no_pi | one_queue | multi_queue | vnet_hdr | tun_excl
                         | {active, false} | {active, true} ]
 
         Device is the TUN/TAP interface name. If an interface name is not

--- a/include/tuntap.hrl
+++ b/include/tuntap.hrl
@@ -56,6 +56,7 @@
 % TUNSETIFF ifr flags
 -define(IFF_TUN, 16#0001).
 -define(IFF_TAP, 16#0002).
+-define(IFF_MULTI_QUEUE, 16#0100).
 -define(IFF_NO_PI, 16#1000).
 -define(IFF_ONE_QUEUE, 16#2000).
 -define(IFF_VNET_HDR, 16#4000).

--- a/src/tunctl_linux.erl
+++ b/src/tunctl_linux.erl
@@ -174,6 +174,7 @@ header(<<?UINT16(Flags), ?UINT16(Proto), Buf/binary>>) ->
 %%
 flag(tun) -> ?IFF_TUN;
 flag(tap) -> ?IFF_TAP;
+flag(multi_queue) -> ?IFF_MULTI_QUEUE;
 flag(no_pi) -> ?IFF_NO_PI;
 flag(one_queue) -> ?IFF_ONE_QUEUE;
 flag(vnet_hdr) -> ?IFF_VNET_HDR;


### PR DESCRIPTION
This adds the `IFF_MULTI_QUEUE` flag to the recognized flags for TUN/TAP creation: https://github.com/torvalds/linux/blob/master/Documentation/networking/tuntap.rst#33-multiqueue-tuntap-interface