### PR TITLE
Adding support for namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _plugins
 _tdeps
 logs
 _build
+erlang_ls.config

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Tuncer is a stand up guy and just like him, tuncer has your back.
         Types   Device = [ string() | binary() ]
                 Options = [ Flag ]
                 Flag = [ tun | tap | no_pi | one_queue | multi_queue | vnet_hdr | tun_excl
-                        | {active, false} | {active, true} ]
+                        | {active, false} | {active, true} | {extra, [ExtraOption]}]
+                ExtraOption = {namespace, string()}
 
         Device is the TUN/TAP interface name. If an interface name is not
         specified, the TUN/TAP driver will choose one (for tap devices,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,1 @@
-[{<<"procket">>,
-  {git,"git://github.com/msantos/procket.git",
-       {ref,"ab084652d8bb67b0bb83a7fc4b049c2e1826b5f3"}},
-  0}].
+[].

--- a/src/tuncer.erl
+++ b/src/tuncer.erl
@@ -383,18 +383,7 @@ up_tunnel(UpCallback, Flag) ->
         undefined ->
             UpCallback();
         NS ->
-            up_into_namespace(UpCallback, NS)
-    end.
-
-up_into_namespace(UpCallback, NS) ->
-    case procket:open_nif("/proc/self/ns/net", read) of
-        {ok, OriginalNsFD} ->
-            ok = procket:setns(NS),
-            UpCallback(),
-            ok = procket:setns_by_fd(OriginalNsFD),
-            procket:close(OriginalNsFD);
-        {error, _R} = E ->
-            E
+            tunctl:up_into_namespace(UpCallback, NS)
     end.
 
 flush_events(Ref, Pid) ->

--- a/src/tunctl_linux.erl
+++ b/src/tunctl_linux.erl
@@ -63,7 +63,8 @@
 create(<<>>, Opt) ->
     create(<<0:(15 * 8)>>, Opt);
 create(Ifname, Opt) when byte_size(Ifname) < ?IFNAMSIZ, is_list(Opt) ->
-    case procket:dev(?TUNDEV) of
+    ExtraOptions = proplists:get_value(extra, Opt, []),
+    case procket:dev(?TUNDEV, ExtraOptions) of
         {ok, FD} ->
             create_1(FD, Ifname, Opt);
         Error ->


### PR DESCRIPTION
WARNING:
To be merged after: https://github.com/msantos/procket/pull/49

This PR add the possibility to create a TUNTAP device inside a specific namespace without leaving the current namespace.
Works only on Llinux.

Example:

```erlang
{ok, TunDevice} = tuncer:create("tun5", [tun, no_pi, {extra, [{namespace, "/var/run/netns/mynetns"}]}]).
ok = tuncer:up(TunDevice, "192.168.123.1").
```