### PR TITLE
git is removed we must use https instead

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-    {procket, {git, "git://github.com/msantos/procket.git", {branch, "master"}}}
+    {procket, {git, "https://github.com/msantos/procket.git", {branch, "master"}}}
 ]}.
 
 {dialyzer, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"procket">>,
-  {git,"git://github.com/msantos/procket.git",
-       {ref,"3520959825a6bf186f3ff08887b7953d685f4ee7"}},
+  {git,"https://github.com/msantos/procket.git",
+       {ref,"531070417f0284e466335f35a94a6bddd1391aad"}},
   0}].


### PR DESCRIPTION
Since March 15, 2022 git protocol is removed we have to use https instead

https://github.blog/2021-09-01-improving-git-protocol-security-github/

