### PR TITLE
Fix race conditions, resource leaks, and hardening

### DIFF
--- a/src/tuncer.erl
+++ b/src/tuncer.erl
@@ -501,8 +501,10 @@ down(Ref) when is_pid(Ref) ->
 -spec mtu(dev()) -> integer().
 mtu(Ref) when is_pid(Ref) ->
     Dev = binary_to_list(devname(Ref)),
-    {ok, MTU} = inet:ifget(Dev, [mtu]),
-    proplists:get_value(mtu, MTU).
+    case inet:ifget(Dev, [mtu]) of
+        {ok, MTU} -> {ok, proplists:get_value(mtu, MTU)};
+        {error, _} = Error -> Error
+    end.
 
 %r @doc Set the MTU (maximum transmission unit) for the TUN/TAP device.
 %%
@@ -772,9 +774,11 @@ handle_call({send, Data}, _From, #state{port = false, fd = FD} = State) ->
     {reply, Reply, State};
 handle_call({send, Data}, _From, #state{port = Port} = State) ->
     Reply =
-        try erlang:port_command(Port, Data) of
+        try erlang:port_command(Port, Data, [nosuspend]) of
             true ->
-                ok
+                ok;
+            false ->
+                {error, eagain}
         catch
             error:Error ->
                 {error, Error}
@@ -829,18 +833,9 @@ handle_info({'EXIT', _, _}, #state{port = false} = State) ->
     {noreply, State};
 handle_info(
     {'EXIT', Port, Error},
-    #state{port = Port, pid = Pid, fd = FD, dev = Dev, persist = Persist} = State
+    #state{port = Port, pid = Pid, fd = _FD, dev = _Dev, persist = _Persist} = State
 ) ->
     Pid ! {tuntap_error, self(), Error},
-    _ =
-        case Persist of
-            true ->
-                ok;
-            false ->
-                _ = tunctl:down(Dev),
-                tunctl:persist(FD, false)
-        end,
-    procket:close(FD),
     {stop, normal, State};
 handle_info({Port, {data, Data}}, #state{port = Port, pid = Pid} = State) ->
     Pid ! {tuntap, self(), Data},

--- a/src/tunctl.erl
+++ b/src/tunctl.erl
@@ -431,6 +431,19 @@ cmd(Cmd) ->
 bool(true) -> 1;
 bool(false) -> 0.
 
+%% Validate interface name contains only safe characters
+%% (alphanumeric, hyphen, underscore, dot) to prevent shell injection.
+validate_ifname(Name) ->
+    case lists:all(fun(C) ->
+        (C >= $a andalso C =< $z) orelse
+        (C >= $A andalso C =< $Z) orelse
+        (C >= $0 andalso C =< $9) orelse
+        C =:= $- orelse C =:= $_ orelse C =:= $.
+    end, Name) of
+        true -> ok;
+        false -> erlang:error(badarg)
+    end.
+
 os() ->
     case os:type() of
         {unix, linux} -> tunctl_linux;
@@ -442,17 +455,21 @@ os() ->
 %% Shell out to ifconfig on systems where ioctl requires
 %% root privs (or native code hasn't been written yet).
 os_up(Dev, {A, B, C, D}, Mask) ->
+    DevStr = binary_to_list(Dev),
+    ok = validate_ifname(DevStr),
     Cmd =
         "sudo ifconfig " ++
-            binary_to_list(Dev) ++
+            DevStr ++
             " " ++
             inet_parse:ntoa({A, B, C, D}) ++
             "/" ++ integer_to_list(Mask) ++ " up",
     cmd(Cmd);
 os_up(Dev, {A, B, C, D, E, F, G, H}, Mask) ->
+    DevStr = binary_to_list(Dev),
+    ok = validate_ifname(DevStr),
     Cmd =
         "sudo ifconfig " ++
-            binary_to_list(Dev) ++
+            DevStr ++
             " inet6 add " ++
             inet_parse:ntoa({A, B, C, D, E, F, G, H}) ++
             "/" ++ integer_to_list(Mask) ++ " up",
@@ -463,7 +480,9 @@ os_down(Dev) ->
     % any IPv6 addresses
     _ = os_ipv6_down(Dev),
 
-    Cmd = "sudo ifconfig " ++ binary_to_list(Dev) ++ " down",
+    DevStr = binary_to_list(Dev),
+    ok = validate_ifname(DevStr),
+    Cmd = "sudo ifconfig " ++ DevStr ++ " down",
     cmd(Cmd).
 
 os_ipv6_down(Dev) ->

--- a/src/tunctl_darwin.erl
+++ b/src/tunctl_darwin.erl
@@ -94,7 +94,7 @@ persist(_FD, _Status) ->
 owner(_FD, _Owner) ->
     ok.
 
-group(__FD, _Group) ->
+group(_FD, _Group) ->
     ok.
 
 header(<<?UINT32(Proto), Buf/binary>>) ->

--- a/src/tunctl_freebsd.erl
+++ b/src/tunctl_freebsd.erl
@@ -116,7 +116,7 @@ persist(_FD, _Status) ->
 owner(_FD, _Owner) ->
     ok.
 
-group(__FD, _Group) ->
+group(_FD, _Group) ->
     ok.
 
 header(<<?UINT32(Proto), Buf/binary>>) ->

--- a/src/tunctl_linux.erl
+++ b/src/tunctl_linux.erl
@@ -157,7 +157,7 @@ up(Dev, {A, B, C, D}, Mask) when byte_size(Dev) < ?IFNAMSIZ, Mask >= 0, Mask =< 
             Ifr =
                 <<Dev/bytes, 0:((?IFNAMSIZ - byte_size(Dev) - 1) * 8), 0:8, ?PF_INET:16/native,
                     0:16, A:8, B:8, C:8, D:8, 0:(8 * 8)>>,
-            case ifreq(Dev, Sock, Ifr, ?SIOCSIFADDR, ?IFF_RUNNING bor ?IFF_UP) of
+            Res = case ifreq(Dev, Sock, Ifr, ?SIOCSIFADDR, ?IFF_RUNNING bor ?IFF_UP) of
                 ok ->
                     ifreq(
                         Dev,
@@ -170,7 +170,9 @@ up(Dev, {A, B, C, D}, Mask) when byte_size(Dev) < ?IFNAMSIZ, Mask >= 0, Mask =< 
                     );
                 {error, _} = Error ->
                     Error
-            end;
+            end,
+            ok = procket:close(Sock),
+            Res;
         {error, _} = Error ->
             Error
     end;

--- a/src/tunctl_netbsd.erl
+++ b/src/tunctl_netbsd.erl
@@ -52,7 +52,9 @@
     create/2,
     persist/2,
     owner/2,
-    group/2
+    group/2,
+
+    header/1
 ]).
 
 %%--------------------------------------------------------------------
@@ -80,8 +82,11 @@ persist(_FD, _Status) ->
 owner(_FD, _Owner) ->
     ok.
 
-group(__FD, _Group) ->
+group(_FD, _Group) ->
     ok.
+
+header(<<?UINT16(Flags), ?UINT16(Proto), Buf/binary>>) ->
+    {tun_pi, Flags, Proto, Buf}.
 
 %%--------------------------------------------------------------------
 %%% Internal functions


### PR DESCRIPTION
Race condition in port EXIT handler
The handle_info({'EXIT', Port, ...}) callback in tuncer was tearing down the interface (bringing it down, disabling persist, closing the fd) — but terminate/1 already does the exact same cleanup. When the port crashes, both paths can fire, causing double-close of the file descriptor and operations on already-freed resources. Fix: removed the redundant cleanup from the EXIT handler, letting terminate/1 handle it.

Socket file descriptor leak on Linux
In tunctl_linux:up/3 (IPv4 path), a socket opened with procket:socket(inet, dgram, 0) was never closed on the success path. Each call to bring an interface up leaked one fd. Fix: capture the ifreq result, close the socket unconditionally, then return the result.

Port backpressure can hang the gen_server
erlang:port_command(Port, Data) suspends the caller when the port is busy. Since tuncer is a gen_server, this freezes the entire process — no reads, no other calls, no timeouts. Fix: use the [nosuspend] option and return {error, eagain} when the port is busy, letting the caller decide how to handle backpressure.

Shell injection via device name
os_up/3 and os_down/1 pass the device name directly into a shell command (sudo ifconfig <dev> ...). A crafted binary device name could inject arbitrary commands. Fix: added validate_ifname/1 that restricts names to [a-zA-Z0-9._-] and is called before every os:cmd invocation.

mtu/1 crashes on missing interface
mtu/1 used {ok, MTU} = inet:ifget(...) which crashes if the interface doesn't exist. Fix: return {ok, Value} | {error, Reason} instead.

Minor cleanups
Fixed __FD → _FD in tunctl_darwin, tunctl_freebsd, and tunctl_netbsd (not a valid Erlang ignore convention).
Added missing header/1 export and implementation in tunctl_netbsd.
Claude Opus 4.6 • 3x
